### PR TITLE
Silverstripe Spamprotection module is now at 3.1.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
   "name": "heyday/silverstripe-honeypot",
   "type": "silverstripe-vendormodule",
   "require": {
-    "silverstripe/spamprotection": "~3.1.0",
+    "silverstripe/spamprotection": "~3.1.0 || ^4",
     "composer/installers": "~1.0"
   },
   "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -2,8 +2,7 @@
   "name": "heyday/silverstripe-honeypot",
   "type": "silverstripe-vendormodule",
   "require": {
-    "silverstripe/spamprotection": "~3.1.0 || ^4",
-    "composer/installers": "~1.0"
+    "silverstripe/spamprotection": "~3.1.0 || ^4"
   },
   "autoload": {
     "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
   "name": "heyday/silverstripe-honeypot",
   "type": "silverstripe-vendormodule",
   "require": {
-    "silverstripe/spamprotection": "~3.0.0",
+    "silverstripe/spamprotection": "~3.1.0",
     "composer/installers": "~1.0"
   },
   "autoload": {


### PR DESCRIPTION
When this is set to ~3.0.0 it won't install the newest silverstripe spam protection module.